### PR TITLE
Docs and refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.d
 deps
 ebin
+cover
 test/*.beam
 doc/*.html
 doc/edoc-info

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT = hnc_pq
-EDOC_OPTS = {todo,true}
+EDOC_OPTS = {stylesheet_file, "priv/edoc-style.css"},{todo,true}
 EUNIT_OPTS = {verbose, true}
 
 ERLANG_MK_BUILD_CONFIG = erlang-mk.build.config

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -1,0 +1,87 @@
+@author Maria Scott <maria-12648430@gmx.net>
+@author Jan Uhlig <j.uhlig@mailingwork.de>
+@copyright 2020 Maria Scott, Jan Uhlig
+@version 0.1.1
+@title hnc-pq - Erlang Priority Queues
+@doc `hnc-pq' is an implementation of priority queues, building on regular
+Erlang queues.
+
+Basically, a `hnc-pq' priority queue consists of a set of <em>priorities</em>,
+which can be any Erlang term, and <em>priority subqueues</em> for each
+priority.
+
+<hr />
+
+The order of priorities is determined by the order in which they appear in the
+priorities list given to ' hnc_pq:new/1', not by term ordering.
+
+Example:
+```
+hnc_pq:new([foo, 1, bar]).
+'''
+The priority queue created by this call has 3 priorities, with `foo' being the
+highest, `1' the second-highest, and `bar' being the lowest priority.
+
+<hr />
+
+While the usual <em>queue order</em> (front to rear) applies to the priority
+subqueues (therefore, referred to by the term <em>priority subqueue order</em>
+or just <em>subqueue order</em> in this context), the concept of priority
+queues neccesitates the definition of <em>priority queue order</em>, meaning
+that items in higher priority subqueues rank higher than items in lower
+priority subqueues, ie the <em>front</em> of a priority queue is the item at
+the front of the highest-priority non-empty subqueue, and the <em>rear</em>
+of a priority queue is the item at the rear of the lowest priority subqueue.
+
+All functions in which execution order may matter traverse in priority queue
+order.
+
+Example:
+
+Assume a priority queue with priorities `a', `b' and `c' (in that order).
+
+If we enqueue items `b1' and `b2' with priority `b', those two items are
+the respective front and rear items of the `b' subqueue, and at the same
+time the front and rear items of the priority queue.
+
+If we now enqueue items `a1' and `a2' with priority `a', those items become
+the respective front and rear items of the `a' subqueue, but now the front
+item of the priority queue is the item `a1', while `b2' stayed the rear
+item of the priority queue.
+
+Finally, if we enqueue two more items `c1' and `c2' with priority `c',
+those two items become the respective front and rear items of the `c'
+subqueue, but now the rear item of the priority queue is the item `c2',
+while `a1' stayed the front item of the priority queue.
+
+<hr />
+
+Many functions come in three flavors. The examples given below assume a
+priority queue `PQ' with priorities `a', `b', and `c', and items `a1',
+`a2', `b1', `b2', `c1', and `c2' in them.
+<ul>
+  <li>Processing an entire priority queue.
+```
+> hnc_pq:out(PQ).
+{a1, ...}
+> hnc_pq:out_r(PQ).
+{c2, ...}
+'''
+      </li>
+  <li>Processing only one specific priority subqueue.
+```
+> hnc_pq:out(b, PQ).
+{b1, ...}
+> hnc_pq:out_r(b, PQ).
+{b2, ...}
+'''
+      </li>
+  <li>Processing a range of priority subqueues.
+```
+> hnc_pq:out(b, c, PQ).
+{b1, ...}
+> hnc_pq:out_r(a, b, PQ).
+{b2, ...}
+'''
+      </li>
+</ul>

--- a/priv/edoc-style.css
+++ b/priv/edoc-style.css
@@ -1,0 +1,68 @@
+/* standard EDoc style sheet */
+body {
+	font-family: Verdana, Arial, Helvetica, sans-serif;
+	margin-left: .25in;
+	margin-right: .2in;
+	margin-top: 0.2in;
+  	margin-bottom: 0.2in;
+	font-size: 10pt;
+   	color: #117;
+  	background-color: #FFF;
+}
+table tr td {
+	font-size: 10pt;
+}
+h1,h2 {
+ 	margin-left: -0.2in;
+}
+div.navbar {
+	background-color: #EEE;
+	margin-left: -0.25in;
+	margin-right: -0.2in;
+	margin-top: -0.2in;
+}
+h2.indextitle {
+	margin-left: -0.25in;
+	margin-right: -0.2in;
+	margin-top: -0.2in;
+	padding: 0.4em;
+	background-color: #EEE;
+}
+h3.function,h3.typedecl {
+	background-color: #EEE;
+ 	padding-left: 1em;
+}
+div.spec {
+ 	margin-left: 2em;
+	background-color: #DDD;
+}
+a, a:visited {
+	color: #55C;
+	text-decoration:none
+}
+a:hover {
+	text-decoration: underline;
+}
+a[name] {
+	text-decoration: none;
+}
+ul.definitions {
+	list-style-type: none;
+}
+ul.index {
+	list-style-type: none;
+	background-color: #EEE;
+}
+
+/*
+ * Minor style tweaks
+ */
+ul {
+	list-style-type: square;
+}
+table {
+	border-collapse: collapse;
+}
+td {
+	padding: 3
+}

--- a/src/hnc_pq.app.src
+++ b/src/hnc_pq.app.src
@@ -15,7 +15,7 @@
 
 {application, 'hnc_pq', [
 	{description, "Erlang priority queues"},
-	{vsn, "0.1.0"},
+	{vsn, "0.1.1"},
 	{modules, ['hnc_pq']},
 	{registered, []},
 	{applications, [kernel,stdlib]},

--- a/src/hnc_pq.erl
+++ b/src/hnc_pq.erl
@@ -13,40 +13,17 @@
 %% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+%% @author Maria Scott <maria-12648430@gmx.net>
+%% @author Jan Uhlig <j.uhlig@mailingwork.de>
+%% @copyright Maria Scott, Jan Uhlig
+%% @version 0.1.1
+
 %% @doc Erlang priority queues.
-%%
-%% `hnc_pq' bundles a set of queues, ranked by priority.
-%%
-%% For most functions, three flavors exist:
-%% <ul>
-%%   <li>Functions addressing the entire priority queue, for example
-%%       `out/1', which will return the item at the front of the
-%%       highest-priority subqueue which is not empty, if any items
-%%       exist in the entire priority queue at all.</li>
-%%   <li>Functions addressing a specific subqueue of the priority
-%%       queue, for example `out/2', which will return the item at
-%%       the front of the given subqueue, if any items exist in that
-%%       subqueue at all.</li>
-%%   <li>Functions addressing a range of subqueues of the priority
-%%       queue, for example `out/3', which will return the item at
-%%       the front of the highest-priority subqueue in the given
-%%       range which is not empty, if any items exist in the given
-%%       range at all.</li>
-%% </ul>
-%%
-%% Functions operate in priority queue order, iterating the subqueues
-%% from highest to lowest priority, and processing each subqueue from
-%% front to rear (except `out_r/1,2,3' which operate in reverse
-%% priority queue order).
-%%
-%% For this reason, the functions addressing a range of subqueues
-%% take the maximum priority as their first and the minimum priority
-%% as their second argument, different from what one might otherwise
-%% be used to.
 -module(hnc_pq).
 
 -export([all/2, all/3, all/4]).
 -export([any/2, any/3, any/4]).
+-export([append/3]).
 -export([filter/2, filter/3, filter/4]).
 -export([fold/3, fold/4, fold/5]).
 -export([from_list/1]).
@@ -54,12 +31,13 @@
 -export([in_r/2, in_r/3]).
 -export([is_empty/1, is_empty/2, is_empty/3]).
 -export([is_priority/2]).
--export([join/2, join/3]).
+-export([join/2]).
 -export([length/1, length/2, length/3]).
 -export([member/2, member/3, member/4]).
 -export([new/1]).
 -export([out/1, out/2, out/3]).
 -export([out_r/1, out_r/2, out_r/3]).
+-export([prepend/3]).
 -export([priorities/1]).
 -export([queue/2]).
 -export([reprioritize/2]).
@@ -69,30 +47,35 @@
 -export([to_flatqueue/1, to_flatqueue/2, to_flatqueue/3]).
 -export([to_list/1, to_list/2, to_list/3]).
 
+-export_type([prioqueue/0, prioqueue/2]).
+
 -record(pq, {
 	p=[]        :: list(Prio),
 	l=undefined :: Prio,
 	q=#{}       :: #{Prio => queue:queue()}
 }).
 
--opaque prioqueue() :: #pq{}.
-%% As returned by `new/1'.
--export_type([prioqueue/0]).
+-opaque prioqueue(Priority, Item) :: #pq{p :: list(Priority), l :: Priority, q :: #{Priority => queue:queue(Item)}}.
 
--type priority() :: term().
-%% Priority label.
+-type prioqueue() :: prioqueue(_, _).
 
--type item() :: term().
-%% Queue item.
+%% ============================================================================
+%% API
+%% ============================================================================
+
+%% ----------------------------------------------------------------------------
+%% new/1
+%% ----------------------------------------------------------------------------
 
 %% @doc Create a new priority queue.
 %% 
-%% The argument given to this function is a list of the priorities
-%% the priority queue should have, in descending order.
+%% @param Priorities A list of unique priorities the priority queue
+%%	should have, in descending order. A priority can be any term. 
+%%
+%% @returns A new, empty priority queue with the given priorities.
 -spec new(Priorities) -> PrioQueue when
 	Priorities :: nonempty_list(Priority),
-	Priority :: priority(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, _).
 new(Prios=[_|_]) ->
 	lists:foldl(
 		fun
@@ -107,13 +90,40 @@ new(Prios=[_|_]) ->
 new(Prios) ->
 	error(badarg, [Prios]).
 
+
+%% ----------------------------------------------------------------------------
+%% to_flatqueue/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Convert a priority queue to a flat queue of items.
+%%
+%% @param PrioQueue The priority queue to convert.
+%%
+%% @returns A queue containing all the items of the priority
+%%	queue, in priority queue order.
+%%
+%% @see to_flatqueue/2
+%% @see to_flatqueue/3
+-spec to_flatqueue(PrioQueue) -> FlatQueue when
+	PrioQueue :: prioqueue(_, Item),
+	FlatQueue :: queue:queue(Item).
+to_flatqueue(PQ=#pq{p=Prios}) ->
+	do_to_flatqueue(Prios, PQ);
+to_flatqueue(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Convert a subqueue of a priority queue to a flat queue of items.
 %%
-%% The items in the result queue are ordered from front to rear.
+%% @param Priority The priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueue to convert.
+%%
+%% @returns A queue containing the items of the given subqueue.
+%%
+%% @see to_flatqueue/1
+%% @see to_flatqueue/3
 -spec to_flatqueue(Priority, PrioQueue) -> FlatQueue when
-	Priority :: priority(),
-	PrioQueue :: prioqueue(),
-	FlatQueue :: queue:queue().
+	PrioQueue :: prioqueue(Priority, Item),
+	FlatQueue :: queue:queue(Item).
 to_flatqueue(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_flatqueue([Prio], PQ);
 to_flatqueue(Prio, PQ) ->
@@ -121,15 +131,20 @@ to_flatqueue(Prio, PQ) ->
 
 %% @doc Convert a range of subqueues of a priority queue to a flat queue of items.
 %%
-%% The items in the result queue are ordered from the front
-%% element of the subqueue with highest priority to the rear element of
-%% the subqueue with the lowest priority, which is the order in which they would
-%% be returned by successive calls to `out/3'.
+%% @param MaxPriority The maximum priority subqueue to convert.
+%% @param MinPriority The minimum priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueues to convert.
+%%
+%% @returns A queue containing the items of the priority subqueues between
+%%	`MaxPriority' and `MinPriority', inclusive, in priority queue order.
+%%
+%% @see to_flatqueue/1
+%% @see to_flatqueue/2
 -spec to_flatqueue(MaxPriority, MinPriority, PrioQueue) -> FlatQueue when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue :: prioqueue(),
-	FlatQueue :: queue:queue().
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	FlatQueue :: queue:queue(Item).
 to_flatqueue(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_flatqueue([Prio], PQ);
 to_flatqueue(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -140,19 +155,7 @@ to_flatqueue(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPri
 to_flatqueue(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Convert a priority queue to a flat queue of items.
-%%
-%% The items in the result queue are ordered from the front
-%% element of the highest priority to the rear element of
-%% the lowest priority, which is the order in which they would
-%% be returned by successive calls to `out/1'.
--spec to_flatqueue(PrioQueue) -> FlatQueue when
-	PrioQueue :: prioqueue(),
-	FlatQueue :: queue:queue().
-to_flatqueue(PQ=#pq{p=Prios}) ->
-	do_to_flatqueue(Prios, PQ);
-to_flatqueue(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_to_flatqueue([], _) ->
 	queue:new();
@@ -165,17 +168,43 @@ do_to_flatqueue(Range, #pq{q=Queues}) ->
 		Range
 	).
 
+
+%% ----------------------------------------------------------------------------
+%% to_list/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Convert a priority queue to a list of priorities and items.
+%%
+%% @param PrioQueue The priority queue to convert.
+%%
+%% @returns A list of tuples of the form `{Priority, Items}', in priority
+%%	queue order, where `Priority' is the priority of a subqueue and
+%%	`Items' is a list of the items in that subqueue.
+%%
+%% @see to_list/2
+%% @see to_list/3
+-spec to_list(PrioQueue) -> PrioList when
+	PrioQueue :: prioqueue(Priority, Item),
+	PrioList :: list({Priority, list(Item)}).
+to_list(PQ=#pq{p=Prios}) ->
+	do_to_list(Prios, PQ);
+to_list(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Convert a specific subqueue of the priority queue to a list of priorities and items.
 %%
-%% The result list contains a tuple of the form `{Priority, Items}' for
-%% each subqueue, in descending priority order. `Items' is a list of the
-%% items in the subqueue, ordered from front to rear.
+%% @param Priority The priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueue to convert.
+%%
+%% @returns A singleton list, with the only element being a tuple of the
+%%	form `{Priority, Items}', where `Priority' is the priority of a
+%%	subqueue and `Items' is a list of the items in that subqueue.
+%%
+%% @see to_list/1
+%% @see to_list/3
 -spec to_list(Priority, PrioQueue) -> PrioList when
-	Priority :: priority(),
-	PrioQueue :: prioqueue(),
-	PrioList :: list({Priority, ItemList}),
-	ItemList :: list(Item),
-	Item :: item().
+	PrioQueue :: prioqueue(Priority, Item),
+	PrioList :: list({Priority, list(Item)}).
 to_list(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_list([Prio], PQ);
 to_list(Prio, PQ) ->
@@ -183,17 +212,21 @@ to_list(Prio, PQ) ->
 
 %% @doc Convert a range of subqueues of the priority queue to a list of items.
 %%
-%% The result list contains a tuple of the form `{Priority, Items}' for
-%% each subqueue, in descending priority order. `Items' is a list of the
-%% items in a subqueue, ordered from front to rear.
+%% @param MaxPriority The maximum priority subqueue to convert.
+%% @param MinPriority The minimum priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueues to convert.
+%%
+%% @returns A list of tuples of the form `{Priority, Items}', in priority
+%%	queue order, where `Priority' is the priority of a subqueue and
+%%	`Items' is a list of the items in that subqueue.
+%%
+%% @see to_list/1
+%% @see to_list/2
 -spec to_list(MaxPriority, MinPriority, PrioQueue) -> PrioList when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue :: prioqueue(),
-	PrioList :: list({Priority, ItemList}),
-	Priority :: priority(),
-	ItemList :: list(Item),
-	Item :: item().
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PrioList :: list({Priority, list(Item)}).
 to_list(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_list([Prio], PQ);
 to_list(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -204,21 +237,7 @@ to_list(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Qu
 to_list(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Convert a priority queue to a list of priorities and items.
-%%
-%% The result list contains a tuple of the form `{Priority, Items}' for
-%% each subqueue, in descending priority order. `Items' is a list of the
-%% items in a subqueue, ordered from front to rear.
--spec to_list(PrioQueue) -> PrioList when
-	PrioQueue :: prioqueue(),
-	PrioList :: list({Priority, ItemList}),
-	Priority :: priority(),
-	ItemList :: list(Item),
-	Item :: item().
-to_list(PQ=#pq{p=Prios}) ->
-	do_to_list(Prios, PQ);
-to_list(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_to_list([], _) ->
 	[];
@@ -231,14 +250,40 @@ do_to_list(Range, #pq{q=Queues}) ->
 		Range
 	).
 
+
+%% ----------------------------------------------------------------------------
+%% to_flatlist/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Convert a priority queue to a flat list of items.
+%%
+%% @param PrioQueue The priority queue to convert.
+%%
+%% @returns A list containing all the items of the priority
+%%	queue, in priority queue order.
+%%
+%% @see to_flatlist/2
+%% @see to_flatlist/3
+-spec to_flatlist(PrioQueue) -> ItemList when
+	PrioQueue :: prioqueue(_, Item),
+	ItemList :: list(Item).
+to_flatlist(PQ=#pq{p=Prios}) ->
+	do_to_flatlist(Prios, PQ);
+to_flatlist(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Convert a subqueue of a priority queue to a flat list of items.
 %%
-%% The items in the result list are ordered from front to rear.
+%% @param Priority The priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueue to convert.
+%%
+%% @returns A list of items in the given subqueue.
+%%
+%% @see to_flatlist/1
+%% @see to_flatlist/3
 -spec to_flatlist(Priority, PrioQueue) -> ItemList when
-	Priority :: priority(),
-	PrioQueue :: prioqueue(),
-	ItemList :: list(Item),
-	Item :: item().
+	PrioQueue :: prioqueue(Priority, Item),
+	ItemList :: list(Item).
 to_flatlist(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_flatlist([Prio], PQ);
 to_flatlist(Prio, PQ) ->
@@ -246,16 +291,20 @@ to_flatlist(Prio, PQ) ->
 
 %% @doc Convert a range of subqueues of a priority queue to a flat list of items.
 %%
-%% The items in the result list are ordered from the front
-%% element of the subqueue with the highest priority to the rear
-%% element of the subqueue with the lowest priority, which is the
-%% order in which they would be returned by successive calls to `out/3'.
+%% @param MaxPriority The maximum priority subqueue to convert.
+%% @param MaxPriority The minimum priority subqueue to convert.
+%% @param PrioQueue The priority queue whose subqueues to convert.
+%%
+%% @returns A list containing the items of the priority subqueues between
+%%	`MaxPriority' and `MinPriority', inclusive, in priority queue order.
+%%
+%% @see to_flatlist/1
+%% @see to_flatlist/2
 -spec to_flatlist(MaxPriority, MinPriority, PrioQueue) -> ItemList when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue :: prioqueue(),
-	ItemList :: list(Item),
-	Item :: item().
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	ItemList :: list(Item).
 to_flatlist(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_to_flatlist([Prio], PQ);
 to_flatlist(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -266,20 +315,7 @@ to_flatlist(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio
 to_flatlist(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Convert a priority queue to a flat list of items.
-%%
-%% The items in the result list are ordered from the front
-%% element of the highest priority to the rear element of
-%% the lowest priority, which is the order in which they would
-%% be returned by successive calls to `out/1'.
--spec to_flatlist(PrioQueue) -> ItemList when
-	PrioQueue :: prioqueue(),
-	ItemList :: list(Item),
-	Item :: item().
-to_flatlist(PQ=#pq{p=Prios}) ->
-	do_to_flatlist(Prios, PQ);
-to_flatlist(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_to_flatlist([], _) ->
 	[];
@@ -292,18 +328,23 @@ do_to_flatlist(Range, #pq{q=Queues}) ->
 		Range
 	).
 
+
+%% ----------------------------------------------------------------------------
+%% from_list/1
+%% ----------------------------------------------------------------------------
+
 %% @doc Create a priority queue from a list.
 %%
-%% The argument list must consist of tuples of the form
-%% `{Priority, Items}', in descending priority order. `Items'
-%% must be a list of the items of a subqueue, in front to
-%% rear order.
+%% @param PrioList A list of tuples of the form `{Priority, Items}',
+%%	in priority queue order, where `Priority' is a priority
+%%	label and `Items' is a list of items in this priority
+%%	subqueue. The priorities must be unique among the list.
+%%
+%% @returns A new priority queue with subqueues according to
+%%	the given priorities, containing the respective items.
 -spec from_list(PrioList) -> PrioQueue when
-	PrioList :: list({Priority, ItemList}),
-	Priority :: priority(),
-	ItemList :: list(Item),
-	Item :: item(),
-	PrioQueue :: prioqueue().
+	PrioList :: list({Priority, list(Item)}),
+	PrioQueue :: prioqueue(Priority, Item).
 from_list(List=[_|_]) ->
 	lists:foldr(
 		fun
@@ -320,20 +361,33 @@ from_list(List=[_|_]) ->
 from_list(List) ->
 	error(badarg, [List]).
 
+
+%% ----------------------------------------------------------------------------
+%% reprioritize/2
+%% ----------------------------------------------------------------------------
+
 %% @doc Change the priorities of a priority queue.
 %%
-%% The resulting priority queue will have the given priorities
-%% in the order specified by the first parameter. Subqueues that
-%% exist in both the priorities list and the priority queue will
-%% remain. Subqueues that exist in the priorities list but not in
-%% the priority queue will be created empty. Subqueues that exist
-%% in the priority queue but not in the priorities list will be
-%% removed.
+%% This function can be used to add, remove, or rearrange priorities
+%% of a priority queue.
+%%
+%% @param Priorities A list of unique new priorities to impose on the
+%%	priority queue.
+%% @param PrioQueue0 The priority queue whose priorities to change.
+%%
+%% @returns A new priority queue with the priorities as specified by
+%%	the `Priorities' parameter, in that order. Priorities that
+%%	exist in both the given priority queue and the new priorities
+%%	list are present as before in the resulting priority queue.
+%%	Priorities that exist in the new priorities but not in the
+%%	given priority queue will be created empty in the resulting
+%%	priority queue. Priorities that exist in the given priority
+%%	queue but not in the new priorities will not be present in the
+%%	resulting priority queue.
 -spec reprioritize(Priorities, PrioQueue0) -> PrioQueue1 when
-	Priorities :: nonempty_list(Priority),
-	Priority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	Priorities :: nonempty_list(NewPriority),
+	PrioQueue0 :: prioqueue(OldPriority, Item),
+	PrioQueue1 :: prioqueue(OldPriority | NewPriority, Item).
 reprioritize(Prios, PQ=#pq{p=Prios}) ->
 	PQ;
 reprioritize(Prios=[_|_], #pq{q=Queues0}) ->
@@ -345,26 +399,67 @@ reprioritize(Prios=[_|_], #pq{q=Queues0}) ->
 reprioritize(Prios, PQ) ->
 	error(badarg, [Prios, PQ]).
 
-%% @doc Reverse the items in a subqueue of a priority queue.
+
+%% ----------------------------------------------------------------------------
+%% reverse/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Reverse the priority queue order of a priority queue.
+%%
+%% @param PrioQueue0 The priority queue to reverse.
+%%
+%% @returns A new priority queue where the priorities of the subqueues
+%%	has been reversed, and the order of items in each subqueue
+%%	has been reversed, also.
+%%
+%% @see reverse/2
+%% @see reverse/3
+-spec reverse(PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
+reverse(PQ=#pq{p=Prios}) ->
+	do_reverse(Prios, PQ);
+reverse(PQ) ->
+	error(badarg, [PQ]).
+
+%% @doc Reverse the order of items in a subqueue of a priority queue.
+%%
+%% @param Priority The priority of the subqueue to reverse.
+%% @param PrioQueue0 The priority whose subqueue to reverse,
+%%
+%% @returns A new priority queue with the items in the given
+%%	subqueue reversed.
+%%
+%% @see reverse/1
+%% @see reverse/3
 -spec reverse(Priority, PrioQueue0) -> PrioQueue1 when
-	Priority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
 reverse(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_reverse([Prio], PQ);
 reverse(Prio, PQ) ->
 	error(badarg, [Prio, PQ]).
 
-%% @doc Reverse a range of subqueues of a priority queue.
+%% @doc Reverse the priority queue order of a range of
+%%	 subqueues of a priority queue.
 %%
-%% The resulting priority queue will have the priorities in the range
-%% in reverse order, and the items in each subqueue in the range will
-%% be in reverse order, also.
+%% @param MaxPriority The maximum priority subqueue to reverse.
+%% @param MaxPriority The minimum priority subqueue to reverse.
+%% @param PrioQueue0 The priority queue whose subqueues to reverse.
+%%
+%% @returns A new priority queue where the priority queue order of
+%%	the subqueues between `MaxPriority' and `MinPriority', inclusive,
+%%	has been reversed. Specifically, this means that the priorities
+%%	of the priority subqueues has been reversed, and the order of the
+%%	items in each of those subqueues has been reversed, also.
+%%
+%% @see reverse/1
+%% @see reverse/2
 -spec reverse(MaxPriority, MinPriority, PrioQueue0) -> PrioQueue1 when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PrioQueue1 :: prioqueue(Priority, Item).
 reverse(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_reverse([Prio], PQ);
 reverse(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -375,17 +470,7 @@ reverse(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Qu
 reverse(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Reverse a priority queue.
-%%
-%% The resulting priority queue will have the priorities in reverse
-%% order, and the items in each subqueue will be in reverse order, also.
--spec reverse(PrioQueue0) -> PrioQueue1 when
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-reverse(PQ=#pq{p=Prios}) ->
-	do_reverse(Prios, PQ);
-reverse(PQ) ->
-	error(badarg, [PQ]).
+%% reverse helper
 
 do_reverse([], PQ) ->
 	PQ;
@@ -402,10 +487,44 @@ do_reverse([Prio|Prios], [Prio|Range], [RPrio|RRange], AccPrios, Queues) ->
 do_reverse([Prio|Prios], Range, RRange, AccPrios, Queues) ->
 	do_reverse(Prios, Range, RRange, [Prio|AccPrios], Queues).
 
+
+%% ----------------------------------------------------------------------------
+%% reverse_priorities/2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Reverse the priorities of a priority queue.
+%%
+%% @param PrioQueue0 The priority queue whose priorities to reverse.
+%%
+%% @returns A new priority queue where the priorities of all subqueues
+%%	has been reversed. The order of items in the respective subqueues
+%%	remains unchanged.
+%%
+%% @see reverse_priorities/3
+-spec reverse_priorities(PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
+reverse_priorities(PQ=#pq{p=Prios}) ->
+	PQ#pq{p=lists:reverse(Prios), l=hd(Prios)};
+reverse_priorities(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Reverse the priorities of a range of subqueues of a priority queue.
 %%
-%% The resulting priority queue will have the priorities in the given range
-%% in reverse order, but the items in each subqueue will remain in the current order.
+%% @param MaxPriority The maximum priority subqueue whose priority to change.
+%% @param MinPriority The minimum priority subqueue whose priority to change.
+%% @param PrioQueue0 The priority queue whose subqueue priorities to reverse.
+%%
+%% @returns A new priority queue where the priorities of the subqueues between
+%%	`MaxPriority' and `MinPriority', inclusive, has been reversed. The order
+%%	of items in the respective subqueues remains unchanged.
+%%
+%% @see reverse_priorities/1
+-spec reverse_priorities(MaxPriority, MinPriority, PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PrioQueue1 :: prioqueue(Priority, Item).
 reverse_priorities(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	PQ;
 reverse_priorities(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -416,17 +535,7 @@ reverse_priorities(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(
 reverse_priorities(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Reverse the priorities of a priority queue.
-%%
-%% The resulting priority queue will have the priorities in reverse order,
-%% but the items in each subqueue will remain in the current order.
--spec reverse_priorities(PrioQueue0) -> PrioQueue1 when
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-reverse_priorities(PQ=#pq{p=Prios}) ->
-	PQ#pq{p=lists:reverse(Prios), l=hd(Prios)};
-reverse_priorities(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_reverse_priorities([], PQ) ->
 	PQ;
@@ -441,50 +550,122 @@ do_reverse_priorities([Prio|Prios], [Prio|Range], [RPrio|RRange], AccPrios) ->
 do_reverse_priorities([Prio|Prios], Range, RRange, AccPrios) ->
 	do_reverse_priorities(Prios, Range, RRange, [Prio|AccPrios]).
 
+
+%% ----------------------------------------------------------------------------
+%% is_priority/2
+%% ----------------------------------------------------------------------------
+
 %% @doc Check if the given priority exists in a priority queue.
+%%
+%% @param Priority The priority to check for existence.
+%% @param PrioQueue The priority queue in which to check.
+%%
+%% @returns `true' if the given priority exists in the
+%%	given priority queue, otherwise `false'.
 -spec is_priority(Priority, PrioQueue) -> boolean() when
-	Priority :: priority(),
+	Priority :: term(),
 	PrioQueue :: prioqueue().
 is_priority(Prio, #pq{q=Queues}) ->
 	is_map_key(Prio, Queues);
 is_priority(Prio, PQ) ->
 	error(badarg, [Prio, PQ]).
 
+
+%% ----------------------------------------------------------------------------
+%% priorities/1
+%% ----------------------------------------------------------------------------
+
 %% @doc Retrieve the priorities of a priority queue.
+%%
+%% @param PrioQueue The priority queue whose priorities to retrieve.
+%%
+%% @returns A list of the priorities of the given priority queue,
+%%	in descending order.
 -spec priorities(PrioQueue) -> Priorities when
-	PrioQueue :: prioqueue(),
-	Priorities :: nonempty_list(Priority),
-	Priority :: priority().
+	PrioQueue :: prioqueue(Priority, _),
+	Priorities :: list(Priority).
 priorities(#pq{p=Prios}) ->
 	Prios;
 priorities(PQ) ->
 	error(badarg, [PQ]).
 
+
+%% ----------------------------------------------------------------------------
+%% queue/2
+%% ----------------------------------------------------------------------------
+
 %% @doc Retrieve a subqueue of a priority queue.
+%%
+%% @param Priority The priority subqueue to retrieve.
+%% @param PrioQueue The priority queue whose subqueue to retrieve.
+%%
+%% @returns The subqueue with the given priority in the given
+%%	priority queue.
 -spec queue(Priority, PrioQueue) -> Queue when
-	Priority :: priority(),
-	PrioQueue :: prioqueue(),
-	Queue :: queue:queue().
+	PrioQueue :: prioqueue(Priority, Item),
+	Queue :: queue:queue(Item).
 queue(Prio, #pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	maps:get(Prio, Queues);
 queue(Prio, PQ) ->
 	error(badarg, [Prio, PQ]).
 
-%% @doc Check if the given item is a member of a subqueue of a priority queue.
+
+%% ----------------------------------------------------------------------------
+%% member/2,3,4
+%% ----------------------------------------------------------------------------
+
+%% @doc Check if an item is a member of a priority queue.
+%%
+%% @param Item The item whose existence to check.
+%% @param PrioQueue The priority queue whose subqueue to check.
+%%
+%% @returns `true' if the given `Item' is a member of the given
+%%	priority queue, otherwise `false'.
+%%
+%% @see member/3
+%% @see member/4
+-spec member(Item, PrioQueue) -> boolean() when
+	PrioQueue :: prioqueue(_, Item).
+member(Item, PQ=#pq{p=Prios}) ->
+	do_member(Prios, Item, PQ);
+member(Item, PQ) ->
+	error(badarg, [Item, PQ]).
+
+%% @doc Check if an item is a member of a subqueue of a priority queue.
+%%
+%% @param Priority The priority of the subqueue to check.
+%% @param Item The item whose existence to check.
+%% @param PrioQueue The priority queue whose subqueue to check.
+%%
+%% @returns `true' if the given `Item' is a member of the given subqueue
+%%	of the given priority queue, otherwise `false'.
+%%
+%% @see member/2
+%% @see member/4
 -spec member(Priority, Item, PrioQueue) -> boolean() when
-	Priority :: priority(),
-	Item :: item(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, Item).
 member(Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_member([Prio], Item, PQ);
 member(Prio, Item, PQ) ->
 	error(badarg, [Prio, Item, PQ]).
 
+%% @doc Check if an item is a member of a range of subqueues of a priority queue.
+%%
+%% @param MaxPriority The maximum priority subqueue to check.
+%% @param MinPriority The minimum priority subqueue to check.
+%% @param Item The item whose existence to check.
+%% @param PrioQueue The priority queue whose subqueue to check.
+%%
+%% @returns `true' if the given `Item' is a member of the priority subqueues between
+%%	`MaxPriority' and `MinPriority', inclusive, of the given priority queue,
+%%	otherwise `false'.
+%%
+%% @see member/2
+%% @see member/3
 -spec member(MaxPriority, MinPriority, Item, PrioQueue) -> boolean() when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	Item :: item(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority.
 member(Prio, Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_member([Prio], Item, PQ);
 member(MaxPrio, MinPrio, Item, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -495,14 +676,7 @@ member(MaxPrio, MinPrio, Item, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPri
 member(MaxPrio, MinPrio, Item, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, Item, PQ]).
 
-%% @doc Check if the given item is a member of a priority queue.
--spec member(Item, PrioQueue) -> boolean() when
-	Item :: item(),
-	PrioQueue :: prioqueue().
-member(Item, PQ=#pq{p=Prios}) ->
-	do_member(Prios, Item, PQ);
-member(Item, PQ) ->
-	error(badarg, [Item, PQ]).
+%% member helper
 
 do_member([], _, _) ->
 	false;
@@ -514,69 +688,145 @@ do_member(Range, Item, #pq{q=Queues}) ->
 		Range
 	).
 
-%% @doc Insert the given item into a subqueue of a priority queue, at the rear.
--spec in(Priority, Item, PrioQueue0) -> PrioQueue1 when
-	Priority :: priority(),
-	Item :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-in(Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
-	do_in(Prio, Item, PQ);
-in(Prio, Item, PQ) ->
-	error(badarg, [Prio, Item, PQ]).
+
+%% ----------------------------------------------------------------------------
+%% in/2,3
+%% ----------------------------------------------------------------------------
 
 %% @doc Insert the given item into a priority queue, at the rear.
 %%
-%% The item will be inserted at the rear of the subqueue with the lowest priority.
+%% @param Item The item to insert.
+%% @param PrioQueue0 The priority queue into which to insert.
+%%
+%% @returns A new priority queue where the given item has been inserted
+%%	at the rear of the lowest-priority subqueue of the given priority
+%%	queue.
+%%
+%% @see in/3
+%% @see in_r/2
 -spec in(Item, PrioQueue0) -> PrioQueue1 when
-	Item :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item).
 in(Item, PQ=#pq{l=Prio}) ->
 	do_in(Prio, Item, PQ);
 in(Item, PQ) ->
 	error(badarg, [Item, PQ]).
  
+%% @doc Insert an item into a subqueue of a priority queue, at the rear.
+%%
+%% @param Priority The priority subqueue into which to insert.
+%% @param Item The item to insert.
+%% @param PrioQueue0 The priority queue into whose subqueue to insert.
+%%
+%% @returns A new priority queue where the given item has been inserted
+%%	at the rear of the given subqueue of the given priority queue.
+%%
+%% @see in/2
+%% @see in_r/3
+-spec in(Priority, Item, PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item).
+in(Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
+	do_in(Prio, Item, PQ);
+in(Prio, Item, PQ) ->
+	error(badarg, [Prio, Item, PQ]).
+
+%% helper
+ 
 do_in(Prio, Item, PQ=#pq{q=Queues0}) ->
 	Queues1=maps:update_with(Prio, fun (Queue) -> queue:in(Item, Queue) end, Queues0),
 	PQ#pq{q=Queues1}.
 
-%% @doc Insert the given item into a subqueue of a priority queue, at the front.
--spec in_r(Priority, Item, PrioQueue0) -> PrioQueue1 when
-	Priority :: priority(),
-	Item :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-in_r(Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
-	do_in_r(Prio, Item, PQ);
-in_r(Prio, Item, PQ) ->
-	error(badarg, [Prio, Item, PQ]).
+
+%% ----------------------------------------------------------------------------
+%% in_r/2,3
+%% ----------------------------------------------------------------------------
 
 %% @doc Insert the given item into a priority queue, at the front.
 %%
-%% The item will be inserted at the front of the subqueue with the highest priority.
+%% @param Item The item to insert.
+%% @param PrioQueue0 The priority queue into which to insert.
+%%
+%% @returns A new priority queue where the given item has been inserted
+%%	at the front of the highest-priority subqueue of the given priority
+%%	queue.
+%%
+%% @see in_r/3
+%% @see in/2
 -spec in_r(Item, PrioQueue0) -> PrioQueue1 when
-	Item :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item).
 in_r(Item, PQ=#pq{p=[Prio|_]}) ->
 	do_in_r(Prio, Item, PQ);
 in_r(Item, PQ) ->
 	error(badarg, [Item, PQ]).
 
+%% @doc Insert the given item into a subqueue of a priority queue, at the front.
+%%
+%% @param Priority The priority subqueue into which to insert.
+%% @param Item The item to insert.
+%% @param PrioQueue0 The priority queue into whose subqueue to insert.
+%%
+%% @returns A new priority queue where the given item has been inserted
+%%	at the front of the given subqueue of the given priority queue.
+%%
+%% @see in_r/2
+%% @see in/3
+-spec in_r(Priority, Item, PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item).
+in_r(Prio, Item, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
+	do_in_r(Prio, Item, PQ);
+in_r(Prio, Item, PQ) ->
+	error(badarg, [Prio, Item, PQ]).
+
+%% helper
+
 do_in_r(Prio, Item, PQ=#pq{q=Queues0}) ->
 	Queues1=maps:update_with(Prio, fun (Queue) -> queue:in_r(Item, Queue) end, Queues0),
 	PQ#pq{q=Queues1}.
 
+
+%% ----------------------------------------------------------------------------
+%% out/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Retrieve and remove the next item from a priority queue, from the front.
+%%
+%% @param PrioQueue0 The priority queue from which to retrieve an item.
+%%
+%% @returns Either the atom `empty' if all subqueues of the given priority queue are empty,
+%%	or a tuple of the form `{Item, NewPrioQueue}', where `Item' is the item that was
+%%	retrieved from the front of the highest-priority non-empty subqueue and `NewPrioQueue'
+%%	is a new priority queue with that item accordingly removed.
+%%
+%% @see out/2
+%% @see out/3
+%% @see out_r/1
+-spec out(PrioQueue0) -> empty | {Item, PrioQueue1} when
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
+out(PQ=#pq{p=Prios}) ->
+	do_out(Prios, PQ);
+out(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Retrieve and remove the next item from a subqueue of a priority queue, from the front.
 %%
-%% The item will be taken from the front of the specified subqueue. If the subqueue is empty,
-%% the atom `empty' is returned.
+%% @param Priority The priority subqueue from which to retrieve an item.
+%% @param PrioQueue0 The priority queue from whose subqueue to retrieve.
+%%
+%% @returns Either the atom `empty' if the given subqueue is empty, or a tuple of the form
+%%	`{Item, NewPrioQueue}', where `Item' is the item that was retrieved from the front of
+%%	the given subqueue and `NewPrioQueue' is a new priority queue with that item accordingly
+%%	removed.
+%%
+%% @see out/1
+%% @see out/3
+%% @see out_r/2
 -spec out(Priority, PrioQueue0) -> empty | {Item, PrioQueue1} when
-	Priority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
 out(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_out([Prio], PQ);
 out(Prio, PQ) ->
@@ -585,15 +835,24 @@ out(Prio, PQ) ->
 %% @doc Retrieve and remove the next item from a range of subqueues of a priority queue,
 %% from the front.
 %%
-%% The item will be taken from the front of the subqueue with the highest priority
-%% in the given range that is not empty. If all the subqueues are empty, the atom `empty'
-%% is returned.
+%% @param MaxPriority The maximum priority subqueue from which to retrieve an item.
+%% @param MinPriority The minimum priority subqueue from which to retrieve an item.
+%% @param PrioQueue0 The priority queue from whose subqueues to retrieve an item.
+%%
+%% @returns Either the atom `empty' if all subqueues between `MaxPriority'  and
+%%	`MinPriority', inclusive, are empty, or a tuple of the form `{Item, NewPrioQueue}',
+%%	where `Item' is the item that was retrieved from the front of the highest-priority
+%%	non-empty subqueue and `NewPrioQueue' is a new priority queue with that item
+%%	accordingly removed.
+%%
+%% @see out/1
+%% @see out/2
+%% @see out_r/3
 -spec out(MaxPriority, MinPriority, PrioQueue0) -> empty | {Item, PrioQueue1} when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PrioQueue1 :: prioqueue(Priority, Item).
 out(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_out([Prio], PQ);
 out(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -604,18 +863,7 @@ out(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Queues
 out(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Retrieve and remove the next item from a priority queue, from the front.
-%%
-%% The item will be taken from the front of the subqueue with the highest priority
-%% that is not empty. If all subqueues are empty, the atom `empty' is returned.
--spec out(PrioQueue0) -> empty | {Item, PrioQueue1} when
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
-out(PQ=#pq{p=Prios}) ->
-	do_out(Prios, PQ);
-out(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_out([], _) ->
 	empty;
@@ -626,16 +874,48 @@ do_out([Prio|Range], PQ=#pq{q=Queues}) ->
 		{{value, Item}, Queue1} ->
 			{Item, PQ#pq{q=maps:update(Prio, Queue1, Queues)}}
 	end.
-	
+
+
+%% ----------------------------------------------------------------------------
+%% out_r/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Retrieve and remove the next item from a priority queue, from the rear.
+%%
+%% @param PrioQueue0 The priority queue from which to retrieve an item.
+%%
+%% @returns Either the atom `empty' if all subqueues of the given priority queue are empty,
+%%	or a tuple of the form `{Item, NewPrioQueue}', where `Item' is the item that was
+%%	retrieved from the rear of the lowest-priority non-empty subqueue and `NewPrioQueue'
+%%	is a new priority queue with that item accordingly removed.
+%%
+%% @see out_r/2
+%% @see out_r/3
+%% @see out_1
+-spec out_r(PrioQueue0) -> empty | {Item, PrioQueue1} when
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
+out_r(PQ=#pq{p=Prios}) ->
+	do_out_r(lists:reverse(Prios), PQ);
+out_r(PQ) ->
+	error(badarg, [PQ]).
+
 %% @doc Retrieve and remove the next item from a subqueue of a priority queue, from the rear.
 %%
-%% The item will be taken from the rear of the specified subqueue. If the subqueue is empty,
-%% the atom `empty' is returned.
+%% @param Priority The priority subqueue from which to retrieve an item.
+%% @param PrioQueue0 The priority queue from whose subqueue to retrieve.
+%%
+%% @returns Either the atom `empty' if the given subqueue is empty, or a tuple of the form
+%%	`{Item, NewPrioQueue}', where `Item' is the item that was retrieved from the rear of
+%%	the given subqueue and `NewPrioQueue' is a new priority queue with that item accordingly
+%%	removed.
+%%
+%% @see out_r/1
+%% @see out_r/3
+%% @see out/2
 -spec out_r(Priority, PrioQueue0) -> empty | {Item, PrioQueue1} when
-	Priority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	PrioQueue1 :: prioqueue(Priority, Item).
 out_r(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_out_r([Prio], PQ);
 out_r(Prio, PQ) ->
@@ -644,15 +924,24 @@ out_r(Prio, PQ) ->
 %% @doc Retrieve and remove the next item from a range of subqueues of a priority queue,
 %% from the rear.
 %%
-%% The item will be taken from the rear of the subqueue with the lowest priority
-%% in the given range that is not empty. If all the subqueues are empty, the atom `empty'
-%% is returned.
+%% @param MaxPriority The maximum priority subqueue from which to retrieve an item.
+%% @param MinPriority The minimum priority subqueue from which to retrieve an item.
+%% @param PrioQueue0 The priority queue from whose subqueues to retrieve an item.
+%%
+%% @returns Either the atom `empty' if all subqueues between `MaxPriority'  and
+%%	`MinPriority', inclusive, are empty, or a tuple of the form `{Item, NewPrioQueue}',
+%%	where `Item' is the item that was retrieved from the rear of the lowest-priority
+%%	non-empty subqueue and `NewPrioQueue' is a new priority queue with that item
+%%	accordingly removed.
+%%
+%% @see out_r/1
+%% @see out_r/2
+%% @see out/3
 -spec out_r(MaxPriority, MinPriority, PrioQueue0) -> empty | {Item, PrioQueue1} when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PrioQueue1 :: prioqueue(Priority, Item).
 out_r(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_out_r([Prio], PQ);
 out_r(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -663,18 +952,7 @@ out_r(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Queu
 out_r(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Retrieve and remove the next item from a priority queue, from the rear.
-%%
-%% The item will be taken from the rear of the subqueue with the lowest priority
-%% that is not empty. If all subqueues are empty, the atom `empty'  is returned.
--spec out_r(PrioQueue0) -> empty | {Item, PrioQueue1} when
-	PrioQueue0 :: prioqueue(),
-	Item :: item(),
-	PrioQueue1 :: prioqueue().
-out_r(PQ=#pq{p=Prios}) ->
-	do_out_r(lists:reverse(Prios), PQ);
-out_r(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_out_r([], _) ->
 	empty;
@@ -686,20 +964,59 @@ do_out_r([Prio|Range], PQ=#pq{q=Queues}) ->
 			{Item, PQ#pq{q=maps:update(Prio, Queue1, Queues)}}
 	end.
 
-%% @doc Check if a subqueue of a priority queue is empty.
--spec is_empty(Priority, PrioQueue) -> boolean() when
-	Priority :: priority(),
+
+%% ----------------------------------------------------------------------------
+%% is_empty/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Check if a priority queue is empty.
+%%
+%% @param PrioQueue The priority queue to check.
+%%
+%% @returns `true' if the entire priority queue is empty,
+%%	otherwise `false'.
+%%
+%% @see is_empty/2
+%% @see is_empty/3
+-spec is_empty(PrioQueue) -> boolean() when
 	PrioQueue :: prioqueue().
+is_empty(PQ=#pq{p=Prios}) ->
+	do_is_empty(Prios, PQ);
+is_empty(PQ) ->
+	error(badarg, [PQ]).
+
+%% @doc Check if a subqueue of a priority queue is empty.
+%%
+%% @param Priority The priority subqueue to check.
+%% @param PrioQueue The priority queue whose subqueue to check.
+%%
+%% @returns `true' if the given subqueue is empty, otherwise
+%%	`false'.
+%%
+%% @see is_empty/1
+%% @see is_empty/3
+-spec is_empty(Priority, PrioQueue) -> boolean() when
+	PrioQueue :: prioqueue(Priority, _).
 is_empty(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_is_empty([Prio], PQ);
 is_empty(Prio, PQ) ->
 	error(badarg, [Prio, PQ]).
 
 %% @doc Check if a range of subqueues of a priority queue is empty.
+%%
+%% @param MaxPriority The maximum priority subqueue to check.
+%% @param MinPriority The minimum priority subqueue to check.
+%% @param PrioQueue The priority queue whose subqueues to check.
+%%
+%% @returns `true' if all subqueues between `MaxPriority' and `MinPriority',
+%%	inclusive, are empty, otherwise `false'.
+%%
+%% @see is_empty/1
+%% @see is_empty/2
 -spec is_empty(MaxPriority, MinPriority, PrioQueue) -> boolean() when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, _),
+	MaxPriority :: Priority,
+	MinPriority :: Priority.
 is_empty(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_is_empty([Prio], PQ);
 is_empty(MaxPrio, MinPrio, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) ->
@@ -710,13 +1027,7 @@ is_empty(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Q
 is_empty(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Check if a priority queue is empty.
--spec is_empty(PrioQueue) -> boolean() when
-	PrioQueue :: prioqueue().
-is_empty(PQ=#pq{p=Prios}) ->
-	do_is_empty(Prios, PQ);
-is_empty(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_is_empty([], _) ->
 	true;
@@ -728,10 +1039,39 @@ do_is_empty([Prio|Range], PQ=#pq{q=Queues}) ->
 			false
 	end.
 
-%% @doc Retrieve the number of items in a subqueue of a priority queue.
--spec length(Priority, PrioQueue) -> Length when
-	Priority :: priority(),
+
+%% ----------------------------------------------------------------------------
+%% length/1,2,3
+%% ----------------------------------------------------------------------------
+
+%% @doc Retrieve the number of items in a priority queue.
+%%
+%% @param PrioQueue The priority queue whose length to retrieve.
+%%
+%% @returns The number of items in the entire priority queue.
+%%
+%% @see length/2
+%% @see length/3
+-spec length(PrioQueue) -> Length when
 	PrioQueue :: prioqueue(),
+	Length :: non_neg_integer().
+length(PQ=#pq{p=Prios}) ->
+	do_length(Prios, PQ);
+length(PQ) ->
+	error(badarg, [PQ]).
+
+%% @doc Retrieve the number of items in a subqueue of a priority queue.
+%%
+%% @param Priority The priority subqueue whose length to retrieve.
+%% @param PrioQueue The priority queue whose subqueue's length to retrieve.
+%%
+%% @returns The number of items in the given priority subqueue of the given
+%%	priority queue.
+%%
+%% @see length/1
+%% @see length/3
+-spec length(Priority, PrioQueue) -> Length when
+	PrioQueue :: prioqueue(Priority, _),
 	Length :: non_neg_integer().
 length(Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_length([Prio], PQ);
@@ -739,10 +1079,20 @@ length(Prio, PQ) ->
 	error(badarg, [Prio, PQ]).
 
 %% @doc Retrieve the number of items in a range of subqueues of a priority queue.
+%%
+%% @param MaxPriority The maximum priority subqueue whose length to retrieve.
+%% @param MinPriority The minimum priority subqueue whose length to retrieve.
+%% @param PrioQueue The priority queue whose subqueues length to retrieve.
+%%
+%% @returns The number of items in the subqueues between `MaxPriority' and `MinPriority',
+%%	inclusive, of the given priority queue.
+%%
+%% @see length/1
+%% @see length/2
 -spec length(MaxPriority, MinPriority, PrioQueue) -> Length when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PrioQueue :: prioqueue(),
+	PrioQueue :: prioqueue(Priority, _),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
 	Length :: non_neg_integer().
 length(Prio, Prio, PQ=#pq{q=Queues}) when is_map_key(Prio, Queues) ->
 	do_length([Prio], PQ);
@@ -754,14 +1104,7 @@ length(MaxPrio, MinPrio, PQ=#pq{p=Prios, q=Queues}) when is_map_key(MaxPrio, Que
 length(MaxPrio, MinPrio, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, PQ]).
 
-%% @doc Retrieve the number of items in a priority queue.
--spec length(PrioQueue) -> Length when
-	PrioQueue :: prioqueue(),
-	Length :: non_neg_integer().
-length(PQ=#pq{p=Prios}) ->
-	do_length(Prios, PQ);
-length(PQ) ->
-	error(badarg, [PQ]).
+%% helper
 
 do_length([], _) ->
 	0;
@@ -776,105 +1119,200 @@ do_length(Range, #pq{q=Queues}) ->
 		maps:with(Range, Queues)
 	).
 
-%% @doc Append or prepend a queue to a subqueue of a priority queue.
+
+%% ----------------------------------------------------------------------------
+%% append/3
+%% ----------------------------------------------------------------------------
+
+%% @doc Append to an existing subqueue or create a new subqueue in a priority queue.
 %%
-%% If the second argument is a queue and the third argument is a priority
-%% queue, the queue is prepended to the specified subqueue of the priority
-%% queue.
-%% If the second argument is a priority queue and the third argument is a
-%% queue, the queue is appended to the specified subqueue of the priority
-%% queue.
--spec join(Priority, PrioQueue0, JoinQueue) -> PrioQueue1 when
-	Priority :: priority(),
-	PrioQueue0 :: prioqueue(),
-	JoinQueue :: queue:queue(),
-	PrioQueue1 :: prioqueue();
-          (Priority, JoinQueue, PrioQueue0) -> PrioQueue1 when
-	Priority :: priority(),
-	JoinQueue :: queue:queue(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-join(Prio, PQ=#pq{q=Queues0}, JoinQueue) when is_map_key(Prio, Queues0) ->
-	Queues1=case queue:is_queue(JoinQueue) of
+%% @param Priority The priority of the subqueue to append to or create.
+%% @param AppendQueue A queue to append or create in the given priority queue.
+%%	If a priority subqueue with the given `Priority' exists in the priority queue,
+%%	the queue is appended to the existing queue, otherwise the queue is created as
+%%	the new lowest-priority subqueue.
+%% @param PrioQueue0 The priority queue to whose subqueue to append to or in
+%%	which to create a new subqueue.
+%%
+%% @returns A new priority queue with the given `AppendQueue' appended to
+%%	an existing priority subqueue, or created as a new lowest-priority subqueue.
+%%
+%% @see prepend/3
+%% @see join/2
+-spec append(Priority, PrioQueue0, AppendQueue) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority0, Item0),
+	AppendQueue :: queue:queue(Item1),
+	PrioQueue1 :: prioqueue(Priority0 | Priority, Item0 | Item1).
+append(Prio, PQ=#pq{q=Queues0}, AppendQueue) when is_map_key(Prio, Queues0) ->
+	Queues1=case queue:is_queue(AppendQueue) of
 		true ->
-			maps:update_with(Prio, fun (Queue) -> queue:join(Queue, JoinQueue) end, Queues0);
+			maps:update_with(Prio, fun (Queue) -> queue:join(Queue, AppendQueue) end, Queues0);
 		false ->
-			error(badarg, [Prio, PQ, JoinQueue])
+			error(badarg, [Prio, PQ, AppendQueue])
 	end,
 	PQ#pq{q=Queues1};
-join(Prio, JoinQueue, PQ=#pq{q=Queues0}) when is_map_key(Prio, Queues0) ->
-	Queues1=case queue:is_queue(JoinQueue) of
+append(Prio, PQ=#pq{p=Prios0, q=Queues0}, AppendQueue) ->
+	Queues1=case queue:is_queue(AppendQueue) of
 		true ->
-			maps:update_with(Prio, fun (Queue) -> queue:join(JoinQueue, Queue) end, Queues0);
+			maps:put(Prio, AppendQueue, Queues0);
 		false ->
-			error(badarg, [Prio, PQ, JoinQueue])
+			error(badarg, [Prio, PQ, AppendQueue])
+	end,
+	#pq{p=Prios0++[Prio], l=Prio, q=Queues1};
+append(Prio, PQ, AppendQueue) ->
+	error(badarg, [Prio, PQ, AppendQueue]).
+
+
+%% ----------------------------------------------------------------------------
+%% prepend/3
+%% ----------------------------------------------------------------------------
+
+%% @doc Prepend to an existing subqueue or create a new subqueue in a priority queue.
+%%
+%% @param Priority The priority of the subqueue to prepend to or create.
+%% @param PrependQueue A queue to prepend or create in the given priority queue.
+%%	If a priority subqueue with the given `Priority' exists in the priority queue,
+%%	the queue is prepended to the existing queue, otherwise the queue is created as
+%%	the new highest-priority subqueue.
+%% @param PrioQueue0 The priority queue to whose subqueue to prepend to or in
+%%	which to create a new subqueue.
+%%
+%% @returns A new priority queue with the given `PrependQueue' prepended to
+%%	an existing priority subqueue, or created as a new highest-priority subqueue.
+%%
+%% @see append/3
+%% @see join/2
+-spec prepend(Priority, PrioQueue0, PrependQueue) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority0, Item0),
+	PrependQueue :: queue:queue(Item1),
+	PrioQueue1 :: prioqueue(Priority0 | Priority, Item0 | Item1).
+prepend(Prio, PQ=#pq{q=Queues0}, PrependQueue) when is_map_key(Prio, Queues0) ->
+	Queues1=case queue:is_queue(PrependQueue) of
+		true ->
+			maps:update_with(Prio, fun (Queue) -> queue:join(PrependQueue, Queue) end, Queues0);
+		false ->
+			error(badarg, [Prio, PQ, PrependQueue])
 	end,
 	PQ#pq{q=Queues1};
-join(Prio, PQ, JoinQueue) ->
-	error(badarg, [Prio, PQ, JoinQueue]).
+prepend(Prio, PQ=#pq{p=Prios0, q=Queues0}, PrependQueue) ->
+	Queues1=case queue:is_queue(PrependQueue) of
+		true ->
+			maps:put(Prio, PrependQueue, Queues0);
+		false ->
+			error(badarg, [Prio, PQ, PrependQueue])
+	end,
+	PQ#pq{p=[Prio|Prios0], q=Queues1};
+prepend(Prio, PQ, PrependQueue) ->
+	error(badarg, [Prio, PQ, PrependQueue]).
+
+
+%% ----------------------------------------------------------------------------
+%% join/2
+%% ----------------------------------------------------------------------------
 
 %% @doc Join two priority queues.
 %%
-%% Both priority queues must have the same priorities in the same order.
+%% @param PrioQueue0 The priority queue to join with `PrioQueue1'.
+%% @param PrioQueue1 The priority queue to join with `PrioQueue0'.
 %%
-%% The subqueues of the second priority queue will be appended to
-%% their respective counterparts in of the first priority queue.
+%% @returns A new priority queue where all subqueues in `PrioQueue1'
+%%	which exist in `PrioQueue0' have been appended, and all
+%%	non-existing subqueues have been inserted as new lowest-priority
+%%	subqueues, in the order in which they appear in `PrioQueue1'.
 -spec join(PrioQueue0, PrioQueue1) -> PrioQueue2 when
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue(),
-	PrioQueue2 :: prioqueue().
-join(#pq{p=Prios, q=Queues1}, #pq{p=Prios, q=Queues2}) ->
-	Queues3=maps:map(
-		fun (Prio, Queue1) ->
-			Queue2=maps:get(Prio, Queues2),
-			queue:join(Queue1, Queue2)
+	PrioQueue0 :: prioqueue(Priority0, Item0),
+	PrioQueue1 :: prioqueue(Priority1, Item1),
+	PrioQueue2 :: prioqueue(Priority0 | Priority1, Item0 | Item1).
+join(#pq{p=Prios0, q=Queues0}, #pq{p=Prios1, q=Queues1}) ->
+	Queues2=maps:map(
+		fun
+			(Prio, Queue0) when is_map_key(Prio, Queues1) ->
+				Queue1=maps:get(Prio, Queues1),
+				queue:join(Queue0, Queue1);
+			(_, Queue0) ->
+				Queue0
 		end,
-		Queues1
+		Queues0
 	),
-	#pq{p=Prios, q=Queues3};
-join(PQ1, PQ2) ->
-	error(badarg, [PQ1, PQ2]).
+	Queues3=maps:merge(Queues1, Queues2),
+	Prios2=Prios1--Prios0,
+	Prios3=Prios0++Prios2,
+	#pq{p=Prios3, l=lists:last(Prios3), q=Queues3};
+join(PQ0, PQ1) ->
+	error(badarg, [PQ0, PQ1]).
 
-%% @doc Filter items of a subqueue of a priority queue.
+
+%% ----------------------------------------------------------------------------
+%% filter/2,3,4
+%% ----------------------------------------------------------------------------
+
+%% @doc Filter items of a priority queue, in priority queue order.
 %%
-%% The filter function takes two arguments: the priority of the
-%% subqueue being filtered, and each item in turn. It must return either
-%% `true' to keep the current item, `false' to drop it, or a list
-%% of items that will be inserted in that place instead of the current
-%% item.
+%% @param FilterFun The filter function, which takes two arguments,
+%%	the priority of the subqueue being filtered, and an item.
+%%	It must either return `true' to keep, `false' to discard,
+%%	or a list of items to insert in place of the current item.
+%% @param PrioQueue0 The priority queue whose subqueue to filter.
 %%
-%% The given subqueue is filtered from front to rear.
+%% @return A new priority queue, filtered via `FilterFun'.
+%%
+%% @see filter/3
+%% @see filter/4
+-spec filter(FilterFun, PrioQueue0) -> PrioQueue1 when
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	FilterFun :: fun((Priority, Item0) -> boolean() | list(Item1)),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item1).
+filter(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
+	do_filter(Prios, Fun, PQ);
+filter(Fun, PQ) ->
+	error(badarg, [Fun, PQ]).
+
+%% @doc Filter items of a subqueue of a priority queue, in priority
+%% queue order.
+%%
+%% @param Priority The priority subqueue to filter.
+%% @param FilterFun The filter function, which takes two arguments,
+%%	the priority of the subqueue being filtered, and an item.
+%%	It must either return `true' to keep, `false' to discard,
+%%	or a list of items to insert in place of the current item.
+%% @param PrioQueue0 The priority queue whose subqueue to filter.
+%%
+%% @return A new priority queue with the given subqueue filtered
+%%	via `FilterFun'.
+%%
+%% @see filter/2
+%% @see filter/4
 -spec filter(Priority, FilterFun, PrioQueue0) -> PrioQueue1 when
-	Priority :: priority(),
-	FilterFun :: fun((Priority, QueueItem) -> boolean() | list(InsertItem)),
-	QueueItem :: item(),
-	InsertItem :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	FilterFun :: fun((Priority, Item0) -> boolean() | list(Item1)),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item1).
 filter(Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_filter([Prio], Fun, PQ);
 filter(Prio, Fun, PQ) ->
 	error(badarg, [Prio, Fun, PQ]).
 
-%% @doc Filter items of a range of subqueues of a priority queue.
+%% @doc Filter items of a range of subqueues of a priority queue, in
+%%	priority queue order.
 %%
-%% The filter function takes two arguments: the priority of each subqueue
-%% being filtered in turn, and each item in turn. It must return either
-%% `true' to keep the current item, `false' to drop it, or a list
-%% of items that will be inserted in that place instead of the current
-%% item.
+%% @param MaxPriority The maximum priority subqueue to filter.
+%% @param MinPriority The minimum priority subqueue to filter.
+%% @param FilterFun The filter function, which takes two arguments,
+%%	the priority of the subqueue being filtered, and an item.
+%%	It must either return `true' to keep, `false' to discard,
+%%	or a list of items to insert in place of the current item.
+%% @param PrioQueue0 The priority queue whose subqueue to filter.
 %%
-%% The range is filtered from highest to lowest priority,
-%% and each subqueue is filtered from front to rear.
+%% @return A new priority queue with the subqueues between `MaxPriority'
+%%	and `MinPriority', inclusive, filtered via `FilterFun'.
+%%
+%% @see filter/2
+%% @see filter/3
 -spec filter(MaxPriority, MinPriority, FilterFun, PrioQueue0) -> PrioQueue1 when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	FilterFun :: fun((Priority, QueueItem) -> boolean() | list(InsertItem)),
-	Priority :: priority(),
-	QueueItem :: item(),
-	InsertItem :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
+	PrioQueue0 :: prioqueue(Priority, Item0),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	FilterFun :: fun((Priority, Item0) -> boolean() | list(Item1)),
+	PrioQueue1 :: prioqueue(Priority, Item0 | Item1).
 filter(Prio, Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_filter([Prio], Fun, PQ);
 filter(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) when is_function(Fun, 2) ->
@@ -885,27 +1323,7 @@ filter(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios, q=Queues}) when is_function(Fun, 2
 filter(MaxPrio, MinPrio, Fun, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, Fun, PQ]).
 
-%% @doc Filter items of a priority queue.
-%%
-%% The filter function takes two arguments: the priority of each
-%% subqueue being filtered in turn, and each item in turn. It must
-%% return either `true' to keep the current item, `false' to drop it,
-%% or a list of items that will be inserted in that place instead
-%% of the current item.
-%%
-%% The priority queue is filtered from highest to lowest priority,
-%% and each subqueue is filtered from front to rear.
--spec filter(FilterFun, PrioQueue0) -> PrioQueue1 when
-	FilterFun :: fun((Priority, QueueItem) -> boolean() | list(InsertItem)),
-	Priority :: priority(),
-	QueueItem :: item(),
-	InsertItem :: item(),
-	PrioQueue0 :: prioqueue(),
-	PrioQueue1 :: prioqueue().
-filter(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
-	do_filter(Prios, Fun, PQ);
-filter(Fun, PQ) ->
-	error(badarg, [Fun, PQ]).
+%% helper
 
 do_filter([], _, PQ) ->
 	PQ;
@@ -924,37 +1342,95 @@ do_filter([Prio|Range], Fun, PQ=#pq{q=Queues}) ->
 	),
 	do_filter(Range, Fun, PQ#pq{q=Queues1}).
 
-%% @doc Fold a function over a subqueue of a priority queue.
+
+%% ----------------------------------------------------------------------------
+%% fold/3,4,5
+%% ----------------------------------------------------------------------------
+
+%% @doc Fold a function over a priority queue, in priority queue order.
 %%
-%% The fold function takes three arguments: the priority of the
-%% subqueue being folded over, each item in turn, and an accumulator.
-%% It must return a new accumulator which is then passed to the next
-%% call of the fold function for the next item.
+%% @param FoldFun The fold function, which takes 3 arguments, the
+%%	priority of the subqueue being filtered, an item, and an
+%%	accumulator. It must return a new accumulator, which is then
+%%	passed along in the next call to the fold function.
+%% @param Acc0 The initial value of the accumulator.
+%% @param PrioQueue The priority queue over which to fold.
 %%
-%% The given subqueue is folded from front to rear.
--spec fold(Priority, FoldFun, Acc0, PrioQueue) -> Acc1 when
-	Priority :: priority(),
-	FoldFun :: fun((Priority, QueueItem, AccIn) -> AccOut),
-	QueueItem :: item(),
+%% @returns The last value of the accumulator returned by the fold
+%%	function after being run on successive elements of the
+%%	entire priority queue, or `Acc0' if the priority queue was empty.
+%%
+%% @see fold/4
+%% @see fold/5
+-spec fold(FoldFun, Acc0, PrioQueue) -> Acc1 when
+	PrioQueue :: prioqueue(Priority, Item),
+	FoldFun :: fun((Priority, Item, AccIn) -> AccOut),
 	AccIn :: term(),
 	AccOut :: term(),
 	Acc0 :: term(),
-	PrioQueue :: prioqueue(),
+	Acc1 :: term().
+fold(Fun, Acc0, PQ=#pq{p=Prios}) when is_function(Fun, 3) ->
+	do_fold(Prios, Fun, Acc0, PQ);
+fold(Fun, Acc0, PQ) ->
+	error(badarg, [Fun, Acc0, PQ]).
+
+%% @doc Fold a function over a subqueue of a priority queue, in priority
+%%	queue order.
+%%
+%% @param Priority The priority subqueue to be folded over.
+%% @param FoldFun The fold function, which takes 3 arguments, the
+%%	priority of the subqueue being filtered, an item, and an
+%%	accumulator. It must return a new accumulator, which is then
+%%	passed along in the next call to the fold function.
+%% @param Acc0 The initial value of the accumulator.
+%% @param PrioQueue The priority queue over whose subqueue to fold.
+%%
+%% @returns The last value of the accumulator returned by the fold
+%%	function after being run on successive elements of the given
+%%	subqueue, or `Acc0' if the subqueue was empty.
+%%
+%% @see fold/3
+%% @see fold/5
+-spec fold(Priority, FoldFun, Acc0, PrioQueue) -> Acc1 when
+	PrioQueue :: prioqueue(Priority, Item),
+	FoldFun :: fun((Priority, Item, AccIn) -> AccOut),
+	AccIn :: term(),
+	AccOut :: term(),
+	Acc0 :: term(),
 	Acc1 :: term().
 fold(Prio, Fun, Acc0, PQ=#pq{q=Queues}) when is_function(Fun, 3), is_map_key(Prio, Queues) ->
 	do_fold([Prio], Fun, Acc0, PQ);
 fold(Prio, Fun, Acc0, PQ) ->
 	error(badarg, [Prio, Fun, Acc0, PQ]).
 
-%% @doc Fold a function over a range of subqueues of a priority queue.
+%% @doc Fold a function over a range of subqueues of a priority queue,
+%%	in priority queue order.
 %%
-%% The fold function takes three arguments: the priority of each
-%% subqueue being folded over in turn, each item in turn, and an accumulator.
-%% It must return a new accumulator which is then passed to the next
-%% call of the fold function for the next item.
+%% @param MaxPriority The maximum priority subqueue to be folded over.
+%% @param MinPriority The minimum priority subqueue to be folded over.
+%% @param FoldFun The fold function, which takes 3 arguments, the
+%%	priority of the subqueue being filtered, an item, and an
+%%	accumulator. It must return a new accumulator, which is then
+%%	passed along in the next call to the fold function.
+%% @param Acc0 The initial value of the accumulator.
+%% @param PrioQueue The priority queue over whose subqueues to fold.
 %%
-%% The range is folded over from highest to lowest priority,
-%% and each subqueue is folded over from front to rear.
+%% @returns The last value of the accumulator returned by the fold
+%%	function after being run on successive elements of the
+%%	subqueues between `MaxPriority' and `MinPriority', inclusive,
+%%	or `Acc0' if all the subqueues were empty.
+%%
+%% @see fold/3
+%% @see fold/4
+-spec fold(MaxPriority, MinPriority, FoldFun, Acc0, PrioQueue) -> Acc1 when
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	FoldFun :: fun((Priority, Item, AccIn) -> AccOut),
+	AccIn :: term(),
+	AccOut :: term(),
+	Acc0 :: term(),
+	Acc1 :: term().
 fold(Prio, Prio, Fun, Acc0, PQ=#pq{q=Queues}) when is_function(Fun, 3), is_map_key(Prio, Queues) ->
 	do_fold([Prio], Fun, Acc0, PQ);
 fold(MaxPrio, MinPrio, Fun, Acc0, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) when is_function(Fun, 3) ->
@@ -965,29 +1441,7 @@ fold(MaxPrio, MinPrio, Fun, Acc0, PQ=#pq{p=Prios, q=Queues}) when is_function(Fu
 fold(MaxPrio, MinPrio, Fun, Acc0, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, Fun, Acc0, PQ]).
 
-%% @doc Fold a function over a priority queue.
-%%
-%% The fold function takes three arguments: the priority of each
-%% subqueue being folded over in turn, each item in turn, and
-%% an accumulator.
-%% It must return a new accumulator which is then passed to the next
-%% call of the fold function for the next item.
-%%
-%% The priority queue is folded over from highest to lowest priority,
-%% and each subqueue is folded over from front to rear.
--spec fold(FoldFun, Acc0, PrioQueue) -> Acc1 when
-	FoldFun :: fun((Priority, QueueItem, AccIn) -> AccOut),
-	Priority :: priority(),
-	QueueItem :: item(),
-	AccIn :: term(),
-	AccOut :: term(),
-	Acc0 :: term(),
-	PrioQueue :: prioqueue(),
-	Acc1 :: term().
-fold(Fun, Acc0, PQ=#pq{p=Prios}) when is_function(Fun, 3) ->
-	do_fold(Prios, Fun, Acc0, PQ);
-fold(Fun, Acc0, PQ) ->
-	error(badarg, [Fun, Acc0, PQ]).
+%% helper
 
 do_fold([], _, Acc, _) ->
 	Acc;
@@ -1004,38 +1458,77 @@ do_fold([Prio|Range], Fun, Acc0, PQ=#pq{q=Queues}) ->
 	),
 	do_fold(Range, Fun, Acc1, PQ).
 
+
+%% ----------------------------------------------------------------------------
+%% any/2,3,4
+%% ----------------------------------------------------------------------------
+
+%% @doc Check if at least one item of a priority queue
+%% satisfies a predicate condition, checked in priority queue order.
+%%
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue to check.
+%%
+%% @returns `true' any item in the priority queue satisfies the predicate
+%%	condition, otherwise `false'.
+%%
+%% @see any/3
+%% @see any/4
+-spec any(PredicateFun, PrioQueue) -> boolean() when
+	PrioQueue :: prioqueue(Priority, Item),
+	PredicateFun :: fun((Priority, Item) -> boolean()).
+any(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
+	do_any(Prios, Fun, PQ);
+any(Fun, PQ) ->
+	error(badarg, [Fun, PQ]).
+
 %% @doc Check if at least one item of a subqueue of a
-%% priority queue satisfies a condition.
+%% priority queue satisfies a predicate, checked in priority queue order.
 %%
-%% The predicate function takes two arguments: the priority
-%% of the suqueue being checked, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
+%% @param Priority The priority subqueue to check.
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue whose subqueue to check.
 %%
-%% If the predicate function returns `true' for any item,
-%% this function returns `true', otherwise `false' (including
-%% the case of the subqueue being empty).
+%% @returns `true' if any item in the given subqueue satisfies the predicate
+%%	condition, otherwise `false'.
+%%
+%% @see any/2
+%% @see any/4
 -spec any(Priority, PredicateFun, PrioQueue) -> boolean() when
-	Priority :: priority(),
-	PredicateFun :: fun((Priority, QueueItem) -> boolean()),
-	QueueItem :: item(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, Item),
+	PredicateFun :: fun((Priority, Item) -> boolean()).
 any(Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_any([Prio], Fun, PQ);
 any(Prio, Fun, PQ) ->
 	error(badarg, [Prio, Fun, PQ]).
 
 %% @doc Check if at least one item of a range of subqueues of a
-%% priority queue satisfies a condition.
+%% priority queue satisfies a predicate, checked in priority queue order.
 %%
-%% The predicate function takes two arguments: the priority
-%% of each suqueue being checked in turn, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
+%% @param MaxPriority The maximum priority subqueue to check.
+%% @param MinPriority The minimum priority subqueue to check.
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue whose subqueues to check.
 %%
-%% If the predicate function returns `true' for any item,
-%% this function returns `true', otherwise `false' (including
-%% the case of all the subqueues being empty).
+%% @returns `true' if any item in the subqueues between `MaxPriority' and
+%%	`MinPriority' satisfies the predicate condition, otherwise `false'.
+%%
+%% @see any/2
+%% @see any/3
+-spec any(MaxPriority, MinPriority, PredicateFun, PrioQueue) -> boolean() when
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PredicateFun :: fun((Priority, Item) -> boolean()).
 any(Prio, Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_any([Prio], Fun, PQ);
 any(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) when is_function(Fun, 2) ->
@@ -1046,26 +1539,7 @@ any(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios, q=Queues}) when is_function(Fun, 2), 
 any(MaxPrio, MinPrio, Fun, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, Fun, PQ]).
 
-%% @doc Check if at least one item of a priority queue
-%% satisfies a condition.
-%%
-%% The predicate function takes two arguments: the priority
-%% of each suqueue being checked in turn, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
-%%
-%% If the predicate function returns `true' for any item,
-%% this function returns `true', otherwise `false' (including
-%% the case of the priority queue being empty).
--spec any(PredicateFun, PrioQueue) -> boolean() when
-	PredicateFun :: fun((Priority, QueueItem) -> boolean()),
-	Priority :: priority(),
-	QueueItem :: item(),
-	PrioQueue :: prioqueue().
-any(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
-	do_any(Prios, Fun, PQ);
-any(Fun, PQ) ->
-	error(badarg, [Fun, PQ]).
+%% helper
 
 do_any([], _, _) ->
 	false;
@@ -1085,45 +1559,77 @@ do_any([Prio|Range], Fun, PQ=#pq{q=Queues}) ->
 			do_any(Range, Fun, PQ)
 	end.
 
+
+%% ----------------------------------------------------------------------------
+%% all/2,3,4
+%% ----------------------------------------------------------------------------
+
+%% @doc Check if all items of a priority queue
+%% satisfy a predicate, checked in priority queue order.
+%%
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue to check.
+%%
+%% @returns `true' if all items in the priority queue satisfy the predicate
+%%	condition, otherwise `false'.
+%%
+%% @see all/3
+%% @see all/4
+-spec all(PredicateFun, PrioQueue) -> boolean() when
+	PrioQueue :: prioqueue(Priority, Item),
+	PredicateFun :: fun((Priority, Item) -> boolean()).
+all(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
+	do_all(Prios, Fun, PQ);
+all(Fun, PQ) ->
+	error(badarg, [Fun, PQ]).
+
 %% @doc Check if all items of a subqueue of a
-%% priority queue satisfy a condition.
+%% priority queue satisfy a predicate, checked in priority queue order.
 %%
-%% The predicate function takes two arguments: the priority
-%% of the suqueue being checked, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
+%% @param Priority The priority subqueue to check.
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue whose subqueue to check.
 %%
-%% If the predicate function returns `true' for all items,
-%% this function returns `true' (including the case of the
-%% subqueue being empty), otherwise `false'.
+%% @returns `true' if all items in the given subqueue satisfy the predicate
+%%	condition, otherwise `false'.
+%%
+%% @see all/2
+%% @see all/4
 -spec all(Priority, PredicateFun, PrioQueue) -> boolean() when
-	Priority :: priority(),
-	PredicateFun :: fun((Priority, QueueItem) -> boolean()),
-	QueueItem :: item(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, Item),
+	PredicateFun :: fun((Priority, Item) -> boolean()).
 all(Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_all([Prio], Fun, PQ);
 all(Prio, Fun, PQ) ->
 	error(badarg, [Prio, Fun, PQ]).
 
 %% @doc Check if all items of a range of subqueues of a
-%% priority queue satisfy a condition.
+%% priority queue satisfy a predicate, checked in priority queue order.
 %%
-%% The predicate function takes two arguments: the priority
-%% of each suqueue being checked in turn, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
+%% @param MaxPriority The maximum priority subqueue to check.
+%% @param MinPriority The minimum priority subqueue to check.
+%% @param PredicateFun The predicate function, which takes two arguments,
+%%	the priority of the subqueue being checked, and an item. It must
+%%	return either `true' if the predicate condition is met, otherwise
+%%	`false'.
+%% @param PrioQueue The priority queue whose subqueues to check.
 %%
-%% If the predicate function returns `true' for all items,
-%% this function returns `true' (including the case of all the
-%% subqueues being empty), otherwise `false'.
+%% @returns `true' if all items in the subqueues between `MaxPriority' and
+%%	`MinPriority' satisfy the predicate condition, otherwise `false'.
+%%
+%% @see all/2
+%% @see all/3
 -spec all(MaxPriority, MinPriority, PredicateFun, PrioQueue) -> boolean() when
-	MaxPriority :: priority(),
-	MinPriority :: priority(),
-	PredicateFun :: fun((Priority, QueueItem) -> boolean()),
-	Priority :: priority(),
-	QueueItem :: item(),
-	PrioQueue :: prioqueue().
+	PrioQueue :: prioqueue(Priority, Item),
+	MaxPriority :: Priority,
+	MinPriority :: Priority,
+	PredicateFun :: fun((Priority, Item) -> boolean()).
 all(Prio, Prio, Fun, PQ=#pq{q=Queues}) when is_function(Fun, 2), is_map_key(Prio, Queues) ->
 	do_all([Prio], Fun, PQ);
 all(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios=[MaxPrio|_], l=MinPrio}) when is_function(Fun, 2) ->
@@ -1134,26 +1640,7 @@ all(MaxPrio, MinPrio, Fun, PQ=#pq{p=Prios, q=Queues}) when is_function(Fun, 2), 
 all(MaxPrio, MinPrio, Fun, PQ) ->
 	error(badarg, [MaxPrio, MinPrio, Fun, PQ]).
 
-%% @doc Check if all items of a priority queue
-%% satisfy a condition.
-%%
-%% The predicate function takes two arguments: the priority
-%% of each suqueue being checked in turn, and each item in turn.
-%% It must return `true' if the priority and item satisfies
-%% the condition, otherwise `false'.
-%%
-%% If the predicate function returns `true' for all items,
-%% this function returns `true' (including the case of the
-%% priority queue being empty), otherwise `false'.
--spec all(PredicateFun, PrioQueue) -> boolean() when
-	PredicateFun :: fun((Priority, QueueItem) -> boolean()),
-	Priority :: priority(),
-	QueueItem :: item(),
-	PrioQueue :: prioqueue().
-all(Fun, PQ=#pq{p=Prios}) when is_function(Fun, 2) ->
-	do_all(Prios, Fun, PQ);
-all(Fun, PQ) ->
-	error(badarg, [Fun, PQ]).
+%% helper
 
 do_all([], _, _) ->
 	true;
@@ -1172,6 +1659,10 @@ do_all([Prio|Range], Fun, PQ=#pq{q=Queues}) ->
 		true ->
 			do_all(Range, Fun, PQ)
 	end.
+
+%% ============================================================================
+%% INTERNAL
+%% ============================================================================
 
 select_prio_range(Max, Min, Prios0) ->
 	Prios1=lists:dropwhile(fun (Prio) -> Prio=/=Min end, lists:reverse(Prios0)),


### PR DESCRIPTION
This PR is mostly an overhaul of the entire edoc.
The `join/3` function has been removed in favor of `append/3` and `prepend/3`, and together with `join/2` learned some new tricks ;)